### PR TITLE
Add Ability to Output Optimized Image to a Specified Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ $optimizerChain = OptimizerChainFactory::create();
 $optimizerChain->optimize($pathToImage);
 ```
 
-The image at `$pathToImage` will be overwritten by an optimized version which should be smaller. 
+The image at `$pathToImage` will be overwritten by an optimized version which should be smaller.
+
+To keep the original image, pass through the `$pathToOutput` as an additional argument to optimize the image there:
+```php
+use Spatie\ImageOptimizer\OptimizerChainFactory;
+
+$optimizerChain = OptimizerChainFactory::create();
+
+$optimizerChain->optimize($pathToImage, $pathToOutput);
+```
 
 The package will automatically detect which optimization binaries are installed on your system and use them.
 
@@ -110,7 +119,7 @@ $optimizerChain = OptimizerChainFactory::create();
 $optimizerChain->optimize($pathToImage);
 ```
 
-The image at `$pathToImage` will be overwritten by an optimized version which should be smaller. 
+The image at `$pathToImage` will be overwritten by an optimized version which should be smaller.
 
 The package will automatically detect which optimization binaries are installed on your system and use them.
 
@@ -245,19 +254,19 @@ Original: Photoshop 'Save for web' | PNG-24 with transparency<br>
 
 ![Original](https://spatie.github.io/image-optimizer/examples/logo.png)
 
-Optimized<br> 
+Optimized<br>
 16 Kb (40%)
 
 ![Optimized](https://spatie.github.io/image-optimizer/examples/logo-optimized.png)
 
 ### jpg
 
-Original: Photoshop 'Save for web' | quality 60, optimized<br> 
+Original: Photoshop 'Save for web' | quality 60, optimized<br>
 547 Kb
 
 ![Original](https://spatie.github.io/image-optimizer/examples/image.jpg)
 
-Optimized<br> 
+Optimized<br>
 525 Kb (95%)
 
 ![Optimized](https://spatie.github.io/image-optimizer/examples/image-optimized.jpg)
@@ -266,12 +275,12 @@ credits: Jeff Sheldon, via [Unsplash](https://unsplash.com)
 
 ### svg
 
-Original: Illustrator | Web optimized SVG export<br> 
+Original: Illustrator | Web optimized SVG export<br>
 26 Kb
 
 ![Original](https://spatie.github.io/image-optimizer/examples/graph.svg)
 
-Optimized<br> 
+Optimized<br>
 20 Kb (76%)
 
 ![Optimized](https://spatie.github.io/image-optimizer/examples/graph-optimized.svg)

--- a/src/OptimizerChain.php
+++ b/src/OptimizerChain.php
@@ -58,8 +58,14 @@ class OptimizerChain
         return $this;
     }
 
-    public function optimize(string $pathToImage)
+    public function optimize(string $pathToImage, string $pathToOutput = null)
     {
+        if($pathToOutput)
+        {
+          copy($pathToImage, $pathToOutput);
+          $pathToImage = $pathToOutput;
+        }
+
         $image = new Image($pathToImage);
 
         $this->logger->info("Start optimizing {$pathToImage}");

--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -86,4 +86,20 @@ class OptimizerChainFactoryTest extends TestCase
 
         $this->assertEquals($optimizedContent, $originalContent);
     }
+
+    /** @test */
+    public function it_can_output_to_a_specified_path()
+    {
+        $tempFilePath = $this->getTempFilePath('logo.png');
+        $outputFilePath = __DIR__."/temp/output.png";
+
+        $this->optimizerChain->optimize($tempFilePath, $outputFilePath);
+
+        $this->assertDecreasedFileSize($outputFilePath, $this->getTestFilePath('logo.png'));
+
+        $this->assertOptimizersUsed([
+            Optipng::class,
+            Pngquant::class,
+        ]);
+    }
 }

--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -95,6 +95,7 @@ class OptimizerChainFactoryTest extends TestCase
 
         $this->optimizerChain->optimize($tempFilePath, $outputFilePath);
 
+        $this->assertFileEquals($tempFilePath, $this->getTestFilePath('logo.png'));
         $this->assertDecreasedFileSize($outputFilePath, $this->getTestFilePath('logo.png'));
 
         $this->assertOptimizersUsed([


### PR DESCRIPTION
Added a 2nd argument to the optimize method which specifies where the optimized output of the image should be, the original image will not change. Also created a test to assert output.

```
use Spatie\ImageOptimizer\OptimizerChainFactory;

$optimizerChain = OptimizerChainFactory::create();

$optimizerChain->optimize($pathToImage, $pathToOutput);
```

Not all optimizers have the ability to change output and the syntax for each is different, thus the best solution is to copy original file to output path and optimize the output file.

Please give feedback on this PR as it is hopefully the first of many.