### PR TITLE
Allow Symfony2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "psr/log": "^1.0",
-        "symfony/process": "^3.0"
+        "symfony/process": "^2.8|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",


### PR DESCRIPTION
There shouldn't be any breaking changes in 2.8 -> 3, but this allows to install process on older projects (eg. Magento 2) with older versions.