### PR TITLE
Added missing mime `text/plain` to the list of valid SVG mime types.

### DIFF
--- a/src/Optimizers/Svgo.php
+++ b/src/Optimizers/Svgo.php
@@ -17,7 +17,8 @@ class Svgo extends BaseOptimizer
         return in_array($image->mime(), [
             'text/html',
             'image/svg',
-            'image/svg+xml'
+            'image/svg+xml',
+            'text/plain'
         ]);
     }
 


### PR DESCRIPTION
Maybe not acting mime strict could make more sense on a file type like svg. The variety of mime types detected for a svg is potentially very high from different sources and for different svg contents. 

**Ubuntu example for `image/svg+xml`**
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
… 
</svg>
```

**Ubuntu example for `text/plain`**
```
<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
… 
</svg>
```