### PR TITLE
Removed the symphony/process package version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "psr/log": "^1.0",
-        "symfony/process": "^2.8|^3.0|^4.0"
+        "symfony/process": "^2.8|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2|^7.0",


### PR DESCRIPTION
Removed the `symphony/process` package version `4` from the composer.json to prevent issues with the required PHP version.

`spatie/image-optimizer` requires a minimum PHP version `7.0`. `symphony/process` requires a minimum PHP version `7.1`. So some trouble occurs if installing via composer utilizing the `--ignore-platform-reqs` option.