### PR TITLE
Raise exception when compression process fails

### DIFF
--- a/src/OptimizerChain.php
+++ b/src/OptimizerChain.php
@@ -100,6 +100,10 @@ class OptimizerChain
             ->setTimeout($this->timeout)
             ->run();
 
+        if (! $process->isSuccessful()) {
+            throw new \RuntimeException('Unable to process image. Please check if required binaries are installed');
+        }
+
         $this->logResult($process);
     }
 


### PR DESCRIPTION
#### Use Case
I am using this library in a CakePHP shell/command and rely on `Jpegoptim` optimizer along with copying to different location for compressing/copying images. Recently, as part of setting up the project on a different server, I forgot to install the underlying library used and hence the script was simply copying the images without raising any sort of exception that a certain library is missing or the process being executed is failing.

#### Solution
Although not the most verbose one but now a `RunTimeException` is raised based on whether the process was successful or not (similar to logging based on return status).