### PR TITLE
Require the File Information extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
+        "ext-fileinfo": "*",
         "psr/log": "^1.0",
         "symfony/process": "^2.8|^3.0|^4.0"
     },


### PR DESCRIPTION
Require the [File Information](http://php.net/manual/en/book.fileinfo.php) extension because of [issue #76](https://github.com/spatie/image-optimizer/issues/76).