### PR TITLE
Disable svgo "removeViewBox" plugin by default

### DIFF
--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -30,7 +30,7 @@ class OptimizerChainFactory
             ]))
 
             ->addOptimizer(new Svgo([
-                '--disable=cleanupIDs',
+                '--disable={cleanupIDs,removeViewBox}',
             ]))
 
             ->addOptimizer(new Gifsicle([


### PR DESCRIPTION
ViewBox is an SVG attribute that defines the relative size and aspect ratio of the image. Without this attribute the image can't be scaled using CSS (https://css-tricks.com/scale-svg), it doesn't make sense to remove it when optimizing image for use on the web.

In fact, when image-optimizer was originally written the plugin was disabled by default in svgo, which changed in svgo 1.0, so this PR returns the original intended behavior imo.
