### PR TITLE
Fix empty string setBinaryPath()

### DIFF
--- a/src/Optimizers/BaseOptimizer.php
+++ b/src/Optimizers/BaseOptimizer.php
@@ -24,7 +24,7 @@ abstract class BaseOptimizer implements Optimizer
 
     public function setBinaryPath(string $binaryPath)
     {
-        if (substr($binaryPath, -1) !== DIRECTORY_SEPARATOR) {
+        if (strlen($binaryPath) > 0 && substr($binaryPath, -1) !== DIRECTORY_SEPARATOR) {
             $binaryPath = $binaryPath.DIRECTORY_SEPARATOR;
         }
 

--- a/tests/OptimizerTest.php
+++ b/tests/OptimizerTest.php
@@ -28,6 +28,12 @@ class OptimizerTest extends TestCase
             ->setBinaryPath('testPath/');
 
         $this->assertEquals("\"testPath/jpegoptim\"  'my-image.jpg'", $optimizer->getCommand());
+
+        $optimizer = (new Jpegoptim())
+            ->setImagePath('my-image.jpg')
+            ->setBinaryPath('');
+
+        $this->assertEquals("\"jpegoptim\"  'my-image.jpg'", $optimizer->getCommand());
     }
 
     /** @test */


### PR DESCRIPTION
Fix empty string parameter handling in `setBinaryPath()` with test.
As discussed in https://github.com/spatie/image/pull/110.