### PR TITLE
[WIP] Add Support for MozJPEG

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,27 @@ jobs:
                     sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp
                     sudo npm install -g svgo
 
+            -   name: Build Mozjpeg
+                env:
+                    mozjpeg_version: 4.0.0
+                run: |
+                    sudo apt-get update -y
+                    sudo apt-get install -y build-essential nasm cmake ninja-build curl libpng-dev libpng-tools zlib1g-dev moreutils
+                    curl -fLO "https://github.com/mozilla/mozjpeg/archive/v${mozjpeg_version}.tar.gz"
+                    tar xf "v${mozjpeg_version}.tar.gz"
+                    export CFLAGS='-pipe -flto -no-pie'
+                    export LDFLAGS='-flto -no-pie -static -static-libgcc'
+                    sed -E -i.bk '/^cmake_minimum_required/a\
+                    unset(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)' "mozjpeg-$mozjpeg_version"/CMakeLists.txt
+                    mkdir build && cd build
+                    cmake -G"Ninja" -DENABLE_SHARED=OFF -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_FIND_LIBRARY_SUFFIXES=.a -DCMAKE_LINK_SEARCH_END_STATIC=1 -DCMAKE_LINK_SEARCH_START_STATIC=1 "../mozjpeg-$mozjpeg_version/"
+                    ninja
+                    strip cjpeg-static
+                    sudo rm -f /usr/bin/mozcjpeg
+                    sudo cp cjpeg-static /usr/bin/
+                    sudo mv /usr/bin/cjpeg-static /usr/bin/mozcjpeg
+                    mozcjpeg -version
+
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -18,9 +18,9 @@ class OptimizerChainFactory
         $pngQuality = '--quality=85';
         $mozjpegQuality = '-quality 85';
         if (isset($config['quality'])) {
-            $jpegQuality = '--max=' . $config['quality'];
-            $pngQuality = '--quality=' . $config['quality'];
-            $mozjpegQuality = '-quality ' . $config['quality'];
+            $jpegQuality = '--max='.$config['quality'];
+            $pngQuality = '--quality='.$config['quality'];
+            $mozjpegQuality = '-quality '.$config['quality'];
         }
 
         return (new OptimizerChain())

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -16,11 +16,11 @@ class OptimizerChainFactory
     {
         $jpegQuality = '--max=85';
         $pngQuality = '--quality=85';
-        $MozjpegQuality = '-quality 85';
+        $mozjpegQuality = '-quality 85';
         if (isset($config['quality'])) {
             $jpegQuality = '--max=' . $config['quality'];
             $pngQuality = '--quality=' . $config['quality'];
-            $MozjpegQuality = '-quality ' . $config['quality'];
+            $mozjpegQuality = '-quality ' . $config['quality'];
         }
 
         return (new OptimizerChain())
@@ -31,7 +31,7 @@ class OptimizerChainFactory
             ]))
 
             ->addOptimizer(new Mozjpeg([
-                $jpegQuality
+                $mozjpegQuality,
             ]))
 
             ->addOptimizer(new Pngquant([

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -5,6 +5,7 @@ namespace Spatie\ImageOptimizer;
 use Spatie\ImageOptimizer\Optimizers\Cwebp;
 use Spatie\ImageOptimizer\Optimizers\Gifsicle;
 use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
+use Spatie\ImageOptimizer\Optimizers\Mozjpeg;
 use Spatie\ImageOptimizer\Optimizers\Optipng;
 use Spatie\ImageOptimizer\Optimizers\Pngquant;
 use Spatie\ImageOptimizer\Optimizers\Svgo;
@@ -15,9 +16,11 @@ class OptimizerChainFactory
     {
         $jpegQuality = '--max=85';
         $pngQuality = '--quality=85';
+        $MozjpegQuality = '-quality 85';
         if (isset($config['quality'])) {
-            $jpegQuality = '--max='.$config['quality'];
-            $pngQuality = '--quality='.$config['quality'];
+            $jpegQuality = '--max=' . $config['quality'];
+            $pngQuality = '--quality=' . $config['quality'];
+            $MozjpegQuality = '-quality ' . $config['quality'];
         }
 
         return (new OptimizerChain())
@@ -25,6 +28,10 @@ class OptimizerChainFactory
                 $jpegQuality,
                 '--strip-all',
                 '--all-progressive',
+            ]))
+
+            ->addOptimizer(new Mozjpeg([
+                $jpegQuality
             ]))
 
             ->addOptimizer(new Pngquant([

--- a/src/Optimizers/Mozjpeg.php
+++ b/src/Optimizers/Mozjpeg.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\ImageOptimizer\Optimizers;
+
+use Spatie\ImageOptimizer\Image;
+
+class Mozjpeg extends BaseOptimizer
+{
+    public $binaryName = 'mozcjpeg';
+
+    public function canHandle(Image $image): bool
+    {
+        return $image->mime() === 'image/jpeg';
+    }
+
+    public function getCommand(): string
+    {
+        $optionString = implode(' ', $this->options);
+
+        return "if type \"{$this->binaryPath}{$this->binaryName}\";"
+            . ' then '
+            . "\"{$this->binaryPath}{$this->binaryName}\" {$optionString}"
+            . ' ' . escapeshellarg($this->imagePath)
+            . ' | sponge ' . escapeshellarg($this->imagePath)
+            . '; else echo ". Please check the installation."; fi ';
+    }
+}

--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -6,6 +6,7 @@ use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\ImageOptimizer\Optimizers\Cwebp;
 use Spatie\ImageOptimizer\Optimizers\Gifsicle;
 use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
+use Spatie\ImageOptimizer\Optimizers\Mozjpeg;
 use Spatie\ImageOptimizer\Optimizers\Optipng;
 use Spatie\ImageOptimizer\Optimizers\Pngquant;
 use Spatie\ImageOptimizer\Optimizers\Svgo;
@@ -32,7 +33,10 @@ class OptimizerChainFactoryTest extends TestCase
 
         $this->assertDecreasedFileSize($tempFilePath, $this->getTestFilePath('image.jpg'));
 
-        $this->assertOptimizersUsed(Jpegoptim::class);
+        $this->assertOptimizersUsed([
+            Jpegoptim::class,
+            Mozjpeg::class,
+        ]);
     }
 
     /** @test */
@@ -104,7 +108,7 @@ class OptimizerChainFactoryTest extends TestCase
     public function it_can_output_to_a_specified_path()
     {
         $tempFilePath = $this->getTempFilePath('logo.png');
-        $outputFilePath = __DIR__.'/temp/output.png';
+        $outputFilePath = __DIR__ . '/temp/output.png';
 
         $this->optimizerChain->optimize($tempFilePath, $outputFilePath);
 

--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -108,7 +108,7 @@ class OptimizerChainFactoryTest extends TestCase
     public function it_can_output_to_a_specified_path()
     {
         $tempFilePath = $this->getTempFilePath('logo.png');
-        $outputFilePath = __DIR__ . '/temp/output.png';
+        $outputFilePath = __DIR__.'/temp/output.png';
 
         $this->optimizerChain->optimize($tempFilePath, $outputFilePath);
 


### PR DESCRIPTION
[MozJPEG](https://github.com/mozilla/mozjpeg) improves JPEG compression efficiency achieving higher visual quality and smaller file sizes at the same time. It is compatible with the JPEG standard, and the vast majority of the world's deployed JPEG decoders.

# The Good

Compare to JpegOptim, MozJPEG provides better lossy compression without losing too much the quality of the image. Just check the example below. 

##### Note: 75% quality is an official recommendation by MozJPEG 

| Orginal Image | JpegOptim (85% quality) | MozJPEG  (85% quality) | MozJPEG  (75% quality) | 
| ----------- | ----------- |  ----------- |  ----------- |
| 547 KB | 525 KB (95%) | 461 KB (84%) |  234 KB (43%) |
|  ![Original](https://spatie.github.io/image-optimizer/examples/image.jpg) |  ![Optimized](https://spatie.github.io/image-optimizer/examples/image-optimized.jpg) |![moz-85](https://user-images.githubusercontent.com/7912297/101942826-27cfb880-3c10-11eb-81bb-015a324123fa.jpg)| ![moz-75](https://user-images.githubusercontent.com/7912297/101942936-5057b280-3c10-11eb-94b8-d3acac099f98.jpg) |

# The Bad 

There were lots of issue with **MozJPEG**. I have spent the last two-week finding solutions and implementing it. Let's discuss them one by one. 

<details>
<summary>Issue with overwriting with the image</summary>

In `image-optimizer` the input path and output path is always the same in the command argument. It turns out that MozJPEG does not let you override the input file. Also, the output is provided as stdout. So if you try to redirect stdout to the same file, the shell replaces the file before launching the command, and the command will fail. 

Enter `sponge` from `moreutils` package. It will soak up standard input and write to a file, and it's [available](https://command-not-found.com/sponge) on all OS.  So we can solve our problem like this.

```bash
mozcjpeg -quality 85 example.jpg | sponge example.jpg
```

Now, this introduces one more issue. If MozJPEG is not installed in the system, Above command will destroy the input image (sponge will write the error into the image file). So we need to check if MozJPEG is installed running the command. 

```bash
if type mozcjpeg
then 
   mozcjpeg -quality 85 example.jpg | sponge example.jpg
else 
   echo "Please check the installation."
fi 
```
The above command solves our problem. If the MozJPEG is not installed. It will echo "Please check the installation." into the log and it will not touch the input file.

</details>

<details>

<summary>Building and Installing MozJPEG</summary>

Building MozJPEG is a little bit tricky due to outdated tutorials on the internet (v4 was released recently). So after trying so many things, I was able to make a build script which produces a static linked binary for the MozJPEG. It should work on all Linux OS but have not tested the static binary on Fedora/RHEL/CentOS yet. 

You can check the script here: https://gist.github.com/vikas5914/4affccdfa5c3a722808cd465f77866b9. I am also planning to make a Github Action for this.

MozJPEG is also available via Homebrew. However, I was not able to test this since I don't have a Mac machine.

```bash
brew install mozjpeg
```

There are also many other projects which provide prebuilt binaries like [this](https://github.com/imagemin/mozjpeg-bin/tree/master/vendor) and [this](https://mozjpeg.codelove.de/binaries.html).

If v4 does not work or you get GCC error, you can try to install v3. Both are supported and works fine. 
</details>

<details>
<summary>Is it cjpeg or mozcjpeg ?</summary>

If you try to build or install from a prebuilt binary form the internet, the official binary name is `cjpeg`.

But cjpeg also comes with form the `libjpeg-progs` package on Ubuntu system. To avoid the conflict in name, we will make a symbolic link of MozJPEG's cjpeg as `mozcjpeg`.

</details>

# Next

##### Note: Since English is my 4th language, Writing a doc is harder than writing a code. If there is a plan to merge this PR, I will work on the below items. 

- [ ] Add Docs for Mozjpeg and How to install it. 
- [ ] Test Mozjpeg on MacOS (Maybe via GitHub action?)
- [ ] Test Mozjpeg on Fedora/RHEL/CentOS
- [ ] Look into the MozJPEG's Lossless option