### PR TITLE
README.md: Remove obsolete statement about supported Pngquant version…

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ PNGs will be made smaller by running them through two tools. The first one is [P
 - `-i0`: this will result in a non-interlaced, progressive scanned image
 - `-o2`: this set the optimization level to two (multiple IDAT compression trials)
 
-This package only supports Pngquant 2.5 and lower.
-
 ### SVGs
 
 SVGs will be minified by [SVGO](https://github.com/svg/svgo). SVGO's default configuration will be used, with the omission of the `cleanupIDs` plugin because that one is known to cause troubles when displaying multiple optimized SVGs on one page.


### PR DESCRIPTION
As described in #120, I assume the claim that only Pngquant versions below 2.5 are supported is wrong. It was added in the context of #97 (https://github.com/spatie/image-optimizer/issues/97#issuecomment-542668206, commit 156c4f1), which turned out to be an issue on CentOS/RH (https://github.com/spatie/image-optimizer/issues/97#issuecomment-546177096) and was fixed in their repositories.