### PR TITLE
Strip metadata from PNGs and GIFs & add GIF compression level

### DIFF
--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -31,12 +31,14 @@ class OptimizerChainFactory
                 $pngQuality,
                 '--force',
                 '--skip-if-larger',
+                '--strip',
             ]))
 
             ->addOptimizer(new Optipng([
                 '-i0',
                 '-o2',
                 '-quiet',
+                '-strip all',
             ]))
 
             ->addOptimizer(new Svgo([
@@ -46,6 +48,7 @@ class OptimizerChainFactory
             ->addOptimizer(new Gifsicle([
                 '-b',
                 '-O3',
+                '--no-app-extensions',
             ]))
             ->addOptimizer(new Cwebp([
                 '-m 6',

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -15,9 +15,11 @@ class OptimizerChainFactory
     {
         $jpegQuality = '--max=85';
         $pngQuality = '--quality=85';
+        $gifCompression = '--lossy=15';
         if (isset($config['quality'])) {
             $jpegQuality = '--max='.$config['quality'];
             $pngQuality = '--quality='.$config['quality'];
+            $gifCompression = '--lossy'.(100 - $config['quality']);
         }
 
         return (new OptimizerChain())
@@ -46,6 +48,7 @@ class OptimizerChainFactory
             ]))
 
             ->addOptimizer(new Gifsicle([
+                $gifCompression,
                 '-b',
                 '-O3',
                 '--no-app-extensions',

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -19,7 +19,7 @@ class OptimizerChainFactory
         if (isset($config['quality'])) {
             $jpegQuality = '--max='.$config['quality'];
             $pngQuality = '--quality='.$config['quality'];
-            $gifCompression = '--lossy'.(100 - $config['quality']);
+            $gifCompression = '--lossy='.(100 - $config['quality']);
         }
 
         return (new OptimizerChain())


### PR DESCRIPTION
Hello @freekmurze,

This PR adds the `--lossy` flag of gifsicle to enable lossy compression which reduces the size considerably. The compression will be automatically calculated with the quality config as "compression" is the opposite of "quality": `compression = 100 - quality`.

Also, this PR adds flags to pngquant, optipng and gifsicle to strip optional metadata. The flag was already added with jpegoptim. For cwebp, metadata stripping is already enabled by default in the library.