### PR TITLE
Allow Pest Composer Plugin (fix failing tests)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
         "test": "vendor/bin/phpunit"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }


### PR DESCRIPTION
# Overview

This PR adds the `pestphp/pest-plugin` composer plugin to the list of allowed plugins in the `composer.json` file.

This fixes the failing tests in other PRs.

_id:allow-pest-plugin/v1_