### PR TITLE
WebP Quality Option

### DIFF
--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -19,7 +19,7 @@ class OptimizerChainFactory
         if (isset($config['quality'])) {
             $jpegQuality = '--max='.$config['quality'];
             $pngQuality = '--quality='.$config['quality'];
-            $webpQuality = '-q 80'.$config['quality'];
+            $webpQuality = '-q '.$config['quality'];
         }
 
         return (new OptimizerChain())

--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -15,9 +15,11 @@ class OptimizerChainFactory
     {
         $jpegQuality = '--max=85';
         $pngQuality = '--quality=85';
+        $webpQuality = '-q 80';
         if (isset($config['quality'])) {
             $jpegQuality = '--max='.$config['quality'];
             $pngQuality = '--quality='.$config['quality'];
+            $webpQuality = '-q 80'.$config['quality'];
         }
 
         return (new OptimizerChain())
@@ -48,10 +50,10 @@ class OptimizerChainFactory
                 '-O3',
             ]))
             ->addOptimizer(new Cwebp([
+                $webpQuality,
                 '-m 6',
                 '-pass 10',
                 '-mt',
-                '-q 80',
             ]));
     }
 }


### PR DESCRIPTION
This pull request adds support for a quality setting in WebP, which is based on the existing solutions for JPEG and PNG.
Since this feature does not touch the default value (-q 80) this should not break anything.