### PR TITLE
libavif version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The package will use these optimizers if they are present on your system:
 - [cwebp](https://developers.google.com/speed/webp/docs/precompiled)
 - [avifenc](https://github.com/AOMediaCodec/libavif/blob/main/doc/avifenc.1.md)
 
-Here's how to install all the optimizers on Ubuntu:
+Here's how to install all the optimizers on Ubuntu/Debian:
 
 ```bash
 sudo apt-get install jpegoptim
@@ -61,7 +61,7 @@ sudo apt-get install pngquant
 sudo npm install -g svgo
 sudo apt-get install gifsicle
 sudo apt-get install webp
-sudo apt-get install libavif-bin
+sudo apt-get install libavif-bin # minimum 0.9.3
 ```
 
 And here's how to install the binaries on MacOS (using [Homebrew](https://brew.sh/)):
@@ -75,6 +75,7 @@ brew install gifsicle
 brew install webp
 brew install libavif
 ```
+
 And here's how to install the binaries on Fedora/RHEL/CentOS:
 
 ```bash

--- a/src/Optimizers/Avifenc.php
+++ b/src/Optimizers/Avifenc.php
@@ -20,24 +20,32 @@ class Avifenc extends BaseOptimizer
 
     public function getCommand(): string
     {
+        return $this->getDecodeCommand() .' && '
+            .$this->getEncodeCommand();
+    }
+
+    protected function getDecodeCommand()
+    {
         $this->tmpPath = tempnam(sys_get_temp_dir(), 'avifdec') . '.png';
 
-        $decodeOptionString = implode(' ', [
+        $optionString = implode(' ', [
             '-j all',
             '--ignore-icc',
             '--no-strict',
             '--png-compress 0',
         ]);
-        $encodeOptionString = implode(' ', $this->options);
 
-        $decode = "\"{$this->binaryPath}{$this->decodeBinaryName}\" {$decodeOptionString}"
+        return "\"{$this->binaryPath}{$this->decodeBinaryName}\" {$optionString}"
             .' '.escapeshellarg($this->imagePath)
             .' '.escapeshellarg($this->tmpPath);
+    }
 
-        $encode = "\"{$this->binaryPath}{$this->binaryName}\" {$encodeOptionString}"
+    protected function getEncodeCommand()
+    {
+        $optionString = implode(' ', $this->options);
+
+        return "\"{$this->binaryPath}{$this->binaryName}\" {$optionString}"
             .' '.escapeshellarg($this->tmpPath)
             .' '.escapeshellarg($this->imagePath);
-
-        return $decode . ' && ' . $encode;
     }
 }

--- a/src/Optimizers/Avifenc.php
+++ b/src/Optimizers/Avifenc.php
@@ -20,13 +20,13 @@ class Avifenc extends BaseOptimizer
 
     public function getCommand(): string
     {
-        return $this->getDecodeCommand() .' && '
+        return $this->getDecodeCommand().' && '
             .$this->getEncodeCommand();
     }
 
     protected function getDecodeCommand()
     {
-        $this->tmpPath = tempnam(sys_get_temp_dir(), 'avifdec') . '.png';
+        $this->tmpPath = tempnam(sys_get_temp_dir(), 'avifdec').'.png';
 
         $optionString = implode(' ', [
             '-j all',

--- a/src/Optimizers/Avifenc.php
+++ b/src/Optimizers/Avifenc.php
@@ -11,7 +11,11 @@ class Avifenc extends BaseOptimizer
 
     public function canHandle(Image $image): bool
     {
-        return $image->mime() === 'image/avif' || $image->extension() === 'avif';
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            return $image->extension() === 'avif';
+        }
+
+        return $image->mime() === 'image/avif';
     }
 
     public function getCommand(): string


### PR DESCRIPTION
Currently **Debian 11** (bullseye, which is used in [`php-fpm` Docker image](https://hub.docker.com/_/php) until [`8.0`](https://hub.docker.com/layers/library/php/8.0-fpm/images/sha256-3f36c654ffc091dd0221888bcf870d408064f78669ae343cea2c4f4e394bd713?context=explore)) [only supports](https://pkgs.org/search/?q=libavif-bin) `v0.8.4` `libavif-bin` package, however some `avifdec` options are only [introduced](https://github.com/AOMediaCodec/libavif/blob/v0.9.3/apps/avifdec.c) in `v0.9.3`.

Right now `v0.8.4`'s `avifdec` command produces the following error:
`Too many positional arguments: 0`

And unfortunately there's another issue with `avifenc` command's older version:
`ERROR: Failed to encode image: No codec available` ([ref](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=976349))

Removing the following `avifdec` parameters would fix the decoding command:
- `--ignore-icc`: Set PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.
- `--no-strict`: Disable strict decoding, which disables strict validation checks and errors
- `--png-compress 0`: If the input file contains an embedded ICC profile, ignore it

Unfortunately, there's no easy fix  for `avifenc`'s missing codec issue.

There 2 possible solutions for the situation:
- use Debian 12 (bookworm) which is the default for `php:8.1-fpm` and `php:8.2-fpm` Docker images
- add  `bullseye-backports` as source and install a more recent version `libavif-bin`:
  ```bash
  echo "deb http://deb.debian.org/debian bullseye-backports main" | sudo tee -a /etc/apt/sources.list
  sudo apt install -t bullseye-backports libavif-bin
  ```