### PR TITLE
Allow using Symfony 7 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         "php": "^7.3|^8.0",
         "ext-fileinfo": "*",
         "psr/log": "^1.0 | ^2.0 | ^3.0",
-        "symfony/process": "^4.2|^5.0|^6.0"
+        "symfony/process": "^4.2|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.21",
         "phpunit/phpunit": "^8.5.21|^9.4.4",
-        "symfony/var-dumper": "^4.2|^5.0|^6.0"
+        "symfony/var-dumper": "^4.2|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is needed to keep using this nice package in Symfony 7 applications.

Symfony 7.0 will be released at the end of November 2023 (see https://symfony.com/releases/7.0) but, if possible, it's recommended to make changes like the one in this PR before that release date so people can test their apps with Symfony 7 before the final release.

Thanks!