### PR TITLE
Add PHP 8.2 to the GitHub CI test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4, 7.3]
+                php: [8.2, 8.1, 8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}


### PR DESCRIPTION
Related to #206.

Modern packages like Symfony 7.* will require PHP `>=8.2`, so I propose to add `8.2` to the list of PHP versions tested for this package.

Thanks.