### PR TITLE
Fix OptimizerChainFactory's missing config processor

### DIFF
--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFileEquals;
 
+use Spatie\ImageOptimizer\Optimizer;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\ImageOptimizer\Optimizers\Avifenc;
 use Spatie\ImageOptimizer\Optimizers\Cwebp;
@@ -9,12 +11,52 @@ use Spatie\ImageOptimizer\Optimizers\Gifsicle;
 use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
 use Spatie\ImageOptimizer\Optimizers\Optipng;
 use Spatie\ImageOptimizer\Optimizers\Pngquant;
-
 use Spatie\ImageOptimizer\Optimizers\Svgo;
 
 beforeEach(function () {
     $this->optimizerChain = OptimizerChainFactory::create()
             ->useLogger($this->log);
+});
+
+it('can use config', function () {
+    $this->optimizerChain = OptimizerChainFactory::create([
+        Jpegoptim::class => ['--foo'],
+        Pngquant::class => ['--foo'],
+        Optipng::class => ['--foo'],
+        Svgo::class => ['--foo'],
+        Gifsicle::class => ['--foo'],
+        Cwebp::class => ['--foo'],
+        Avifenc::class => ['--foo'],
+    ])
+    ->useLogger($this->log);
+
+    assertEquals(
+        [
+            new Jpegoptim(['--foo']),
+            new Pngquant(['--foo']),
+            new Optipng(['--foo']),
+            new Svgo(['--foo']),
+            new Gifsicle(['--foo']),
+            new Cwebp(['--foo']),
+            new Avifenc(['--foo']),
+        ],
+        $this->optimizerChain->getOptimizers()
+    );
+});
+
+it('can use default config', function () {
+    assertEquals(
+        [
+           Jpegoptim::class,
+           Pngquant::class,
+           Optipng::class,
+           Svgo::class,
+           Gifsicle::class,
+           Cwebp::class,
+           Avifenc::class,
+        ],
+        array_map(fn (Optimizer $optimizer) => get_class($optimizer), $this->optimizerChain->getOptimizers())
+    );
 });
 
 it('can optimize a jpg', function () {

--- a/tests/OptimizerChainFactoryTest.php
+++ b/tests/OptimizerChainFactoryTest.php
@@ -55,7 +55,12 @@ it('can use default config', function () {
            Cwebp::class,
            Avifenc::class,
         ],
-        array_map(fn (Optimizer $optimizer) => get_class($optimizer), $this->optimizerChain->getOptimizers())
+        array_map(
+            function (Optimizer $optimizer) {
+                return get_class($optimizer);
+            },
+            $this->optimizerChain->getOptimizers()
+        )
     );
 });
 


### PR DESCRIPTION
[OptimizerChainFactory](https://github.com/spatie/image-optimizer/blob/main/src/OptimizerChainFactory.php) is not using the passed configuration (same issue in https://github.com/spatie/laravel-medialibrary/issues/3566).

- Added tests for proof
- Added default config (based on [spatie/laravel-medialibrary/config/media-library.php](https://github.com/spatie/laravel-medialibrary/blob/main/config/media-library.php) / `image_optimizers` with one change: removed `--disable=cleanupIDs` from [SVGO](https://github.com/svg/svgo/releases/tag/v2.0.0))
- Using config (or default config) for creating `OptimizerChain`