### PR TITLE
Drop hard-coded `-i` option from Gifsicle

### DIFF
--- a/src/Optimizers/Gifsicle.php
+++ b/src/Optimizers/Gifsicle.php
@@ -18,7 +18,6 @@ class Gifsicle extends BaseOptimizer
         $optionString = implode(' ', $this->options);
 
         return "\"{$this->binaryPath}{$this->binaryName}\" {$optionString}"
-            // Not using `-i` since that means turn on interlacing, not input file.
             .' '.escapeshellarg($this->imagePath)
             .' --output '.escapeshellarg($this->imagePath);
     }

--- a/src/Optimizers/Gifsicle.php
+++ b/src/Optimizers/Gifsicle.php
@@ -18,7 +18,8 @@ class Gifsicle extends BaseOptimizer
         $optionString = implode(' ', $this->options);
 
         return "\"{$this->binaryPath}{$this->binaryName}\" {$optionString}"
-            .' -i '.escapeshellarg($this->imagePath)
-            .' -o '.escapeshellarg($this->imagePath);
+            // Not using `-i` since that means turn on interlacing, not input file.
+            .' '.escapeshellarg($this->imagePath)
+            .' --output '.escapeshellarg($this->imagePath);
     }
 }

--- a/tests/OptimizerTest.php
+++ b/tests/OptimizerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\ImageOptimizer\Optimizers\Gifsicle;
 use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
 
 it('can accept options via the constructor', function () {
@@ -51,4 +52,10 @@ it('can get jpeg binary name', function () {
 
     expect($optimizer->binaryName())
         ->toBe('jpegoptim');
+});
+
+it('does not hardcode Gifsicle interlace option', function () {
+    $optimizer = new Gifsicle();
+    $optimizer->setImagePath('my-image.gif');
+    expect($optimizer->getCommand())->toBe("\"gifsicle\"  'my-image.gif' --output 'my-image.gif'");
 });


### PR DESCRIPTION
Since [`-i` indicates 'interlacing'](https://github.com/kohler/gifsicle/blob/master/src/support.c#L189) when it [appears to have been added to specify input file](https://github.com/spatie/image-optimizer/commit/81065d85) (for which there is no switch).

Also expand `-o` switch to `--output` for clarity.

Please label the repo and this PR with `hacktoberfest-accepted` so it will count towards [HacktoberFest](https://hacktoberfest.com/participation/) 🙏.